### PR TITLE
Ensure mods are installed to the right places on non-windows

### DIFF
--- a/QBeat/actions.cpp
+++ b/QBeat/actions.cpp
@@ -286,7 +286,11 @@ bool Actions::validateMod(Mod mod, bool includeDependencies )
     }
 
     for( auto& fileToHash : download.mFileHashes ) {
-      QFile tempFile(Settings::instance.bsInstall() + "/" + fileToHash.first );
+
+      QString path = fileToHash.first;
+      Util::fixPath(path);
+
+      QFile tempFile(Settings::instance.bsInstall() + "/" + path );
       tempFile.open(QFile::OpenModeFlag::ReadOnly);
       if( !tempFile.isOpen() ) {
         qOut << "ERROR: Failed to open file for mod verification: " + tempFile.fileName() << "\n";

--- a/QBeat/util.h
+++ b/QBeat/util.h
@@ -6,7 +6,26 @@
 class Util
 {
 public:
+  /// Extract a zip archive to the specified directory
   static bool extractArchive( QString archivePath, QString destDirectory );
+
+  /**
+   * Fixup a path such as plugins -> Plugins
+   * Should be called on all file paths to correct issues in the mod manifest/archive contents
+   */
+  static void fixPath( QString& path );
+private:
+
+  /**
+   * A list of paths known to be wrong in some mod archives
+   *
+   * Not a problem on Windows as the filesystem is case insensitive
+   * but on anything else we end up with files in the wrong folders
+   *
+   * Paths will be checked against these and updated to the correct case
+   * if needed
+   */
+  static QString mBSPathsToFix[];
 };
 
 #endif


### PR DESCRIPTION
Specifically fixes an issue with Song Request Manager, which contains 'plugins' instead of 'Plugins'