### PR TITLE
QBeat enhancements/fixes

### DIFF
--- a/QBeat/actions.cpp
+++ b/QBeat/actions.cpp
@@ -44,11 +44,14 @@ bool Actions::isWinePrefixValid()
   qOut << "Executing: " << script << "\n";
 
   process.setWorkingDirectory(QCoreApplication::applicationDirPath());
+  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
   process.start(script, {Settings::instance.winePrefix()});
   process.waitForStarted(-1);
   process.waitForFinished(-1);
 
-  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
+  if( process.exitCode() != EXIT_SUCCESS ) {
+      qOut << "Script execution failed: \n" << process.readAll() << "\n";
+  }
 
   return process.exitCode() == EXIT_SUCCESS;
 }
@@ -69,11 +72,14 @@ bool Actions::setupWine()
   qOut << "Executing: " << script << "\n";
 
   process.setWorkingDirectory(QCoreApplication::applicationDirPath() );
+  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
   process.start(script, {Settings::instance.winePrefix()});
   process.waitForStarted(-1);
   process.waitForFinished(-1);
 
-  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
+  if( process.exitCode() != EXIT_SUCCESS ) {
+      qOut << "Script execution failed: \n" << process.readAll() << "\n";
+  }
 
   return process.exitCode() == EXIT_SUCCESS;
 }
@@ -92,7 +98,7 @@ bool Actions::patchBeatSaber()
   }
 
   qOut << "Executing: " << script << "\n";
-
+  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
   process.setWorkingDirectory(QCoreApplication::applicationDirPath() );
   process.start(script, {
     Settings::instance.bsInstall(),
@@ -102,7 +108,9 @@ bool Actions::patchBeatSaber()
   process.waitForStarted(-1);
   process.waitForFinished(-1);
 
-  process.setProcessChannelMode(QProcess::ProcessChannelMode::MergedChannels);
+  if( process.exitCode() != EXIT_SUCCESS ) {
+      qOut << "Script execution failed: \n" << process.readAll() << "\n";
+  }
 
   return process.exitCode() == EXIT_SUCCESS;
 }

--- a/QBeat/actions.cpp
+++ b/QBeat/actions.cpp
@@ -343,6 +343,35 @@ bool Actions::validateMod(Mod mod, bool includeDependencies )
   return true;
 }
 
+bool Actions::removeMod(Mod mod)
+{
+  BeatModsV1 api;
+  QTextStream qOut( stdout );
+  for( auto download : mod.mDownloads )
+  {
+    if( download.mType != Settings::instance.gameType() &&
+        download.mType != "universal" ) continue;
+
+    if( download.mFileHashes.empty() ) {
+      qOut << "ERROR: Mod doesn't list any file hashes\n";
+      return false;
+    }
+
+    for( auto& fileToHash : download.mFileHashes ) {
+
+      QString path = fileToHash.first;
+      Util::fixPath(path);
+
+      QFile tempFile(Settings::instance.bsInstall() + "/" + path );
+
+      // Delete the file (and don't worry if it fails)
+      tempFile.remove();
+    }
+  }
+
+  return true;
+}
+
 std::list<Mod> Actions::filterModsToVersion(std::list<Mod> mods, QString version)
 {
   std::list<Mod> res;

--- a/QBeat/actions.cpp
+++ b/QBeat/actions.cpp
@@ -23,12 +23,6 @@ void Actions::printConfig(QTextStream& qOut, QString key) {
   qOut << key << " : " << Settings::instance.value(key).toString() << "\n";
 }
 
-void Actions::setConfig(QString key, QString val) {
-  if( Settings::instance.contains(key) ) {
-    Settings::instance.setValue(key, val);
-  }
-}
-
 bool Actions::isWinePrefixValid()
 {
   QProcess process;

--- a/QBeat/actions.h
+++ b/QBeat/actions.h
@@ -15,7 +15,6 @@ public:
   /// Access the QBeat configuration
   void printAllConfig(QTextStream& qOut);
   void printConfig(QTextStream& qOut, QString key);
-  void setConfig(QString key, QString val);
 
 #ifndef Q_OS_WIN32
   /// Check if the wine prefix is valid for running BSIPA

--- a/QBeat/actions.h
+++ b/QBeat/actions.h
@@ -70,6 +70,11 @@ public:
   Q_INVOKABLE bool validateMod( Mod mod, bool includeDependencies = true );
 
   /**
+   * Remove a mod
+   */
+  Q_INVOKABLE bool removeMod( Mod mod );
+
+  /**
    * @brief Filter a list of mods to a specific game version
    * @param mods List of mods to filter
    * @param version Game version to filter to

--- a/QBeat/main.cpp
+++ b/QBeat/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
   QCommandLineOption actionInstall = {"install", "Install a mod"};
   QCommandLineOption actionValidate = {"validate", "Validate that a mod is installed correctly"};
   QCommandLineOption actionInstallEverything = {"install-all", "Install every mod (WARNING: This is probably a bad idea :O)"};
+  QCommandLineOption actionGUI = {"GUI", "Start the GUI (Incomplete)"};
 
   /*
   QCommandLineOption actionListInstalled = {"list-installed", "List installed mods"};
@@ -69,6 +70,7 @@ int main(int argc, char *argv[])
     actionInstall,
     actionValidate,
     actionInstallEverything,
+    actionGUI,
   /*
     actionListInstalled,
     actionUpdateInstalled,
@@ -270,20 +272,21 @@ int main(int argc, char *argv[])
     }
     return EXIT_SUCCESS;
   }
+  else if( parser.isSet(actionGUI) )
+  {
+    // If nothing specific was requested on the command line start the GUI
+    QQmlApplicationEngine engine;
 
+    qmlRegisterType<Settings>("uk.co.gfrancisdev.qbeat.settings", 1, 0, "Settings");
 
-  // If nothing specific was requested on the command line start the GUI
-  QQmlApplicationEngine engine;
+    const QUrl url(QStringLiteral("qrc:/main.qml"));
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
+                     &app, [url](QObject *obj, const QUrl &objUrl) {
+      if (!obj && url == objUrl)
+        QCoreApplication::exit(-1);
+    }, Qt::QueuedConnection);
+    engine.load(url);
 
-  qmlRegisterType<Settings>("uk.co.gfrancisdev.qbeat.settings", 1, 0, "Settings");
-
-  const QUrl url(QStringLiteral("qrc:/main.qml"));
-  QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
-                   &app, [url](QObject *obj, const QUrl &objUrl) {
-    if (!obj && url == objUrl)
-      QCoreApplication::exit(-1);
-  }, Qt::QueuedConnection);
-  engine.load(url);
-
-  return app.exec();
+    return app.exec();
+  }
 }

--- a/QBeat/main.cpp
+++ b/QBeat/main.cpp
@@ -48,8 +48,9 @@ int main(int argc, char *argv[])
   QCommandLineOption actionDownload = {"download", "(Debug builds only) Download a mod but don't install it"};
 #endif
   QCommandLineOption actionInstall = {"install", "Install a mod"};
-  QCommandLineOption actionValidate = {"validate", "Validate that a mod is installed correctly"};
   QCommandLineOption actionInstallEverything = {"install-all", "Install every mod (WARNING: This is probably a bad idea :O)"};
+  QCommandLineOption actionValidate = {"validate", "Validate that a mod is installed correctly"};
+  QCommandLineOption actionRemove = {"remove", "Uninstall a mod"};
   QCommandLineOption actionGUI = {"GUI", "Start the GUI (Incomplete)"};
 
   /*
@@ -69,6 +70,7 @@ int main(int argc, char *argv[])
 #endif
     actionInstall,
     actionValidate,
+    actionRemove,
     actionInstallEverything,
     actionGUI,
   /*
@@ -245,6 +247,34 @@ int main(int argc, char *argv[])
       return EXIT_SUCCESS;
     } else {
       qOut << "ERROR: Mod not valid, run QBeat --install " << modName << " to fix \n";
+      return EXIT_FAILURE;
+    }
+  }
+  else if( parser.isSet(actionRemove) )
+  {
+    if( Settings::instance.bsInstall().isEmpty() ) {
+      qOut << "ERROR: Beat Saber directory not set, run QBeat --config set " << Settings::kBSInstall << " <dir> to configure\n";
+      return EXIT_FAILURE;
+    }
+    if( parser.positionalArguments().size() < 1 ) {
+      qOut << "USAGE: --remove <mod name>\n";
+      return EXIT_FAILURE;
+    }
+    auto modName = parser.positionalArguments()[0];
+    qOut << "Removing mod: " << modName << "\n";
+    auto mod = actions.getNamedMod(modName);
+    if( mod.mID.size() == 0 ) // TODO: This is nasty
+    {
+      qOut << "ERROR: Unable to find mod named: " << modName << "\n";
+      return EXIT_FAILURE;
+    }
+
+    if( actions.removeMod( mod ) )
+    {
+      qOut << "SUCCESS: Mod removed: " << modName << "\n";
+      return EXIT_SUCCESS;
+    } else {
+      qOut << "ERROR: Failed to remove mod: " << modName << "\n";
       return EXIT_FAILURE;
     }
   }

--- a/QBeat/main.cpp
+++ b/QBeat/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
         actions.printConfig(qOut, parser.positionalArguments()[1]);
         return EXIT_SUCCESS;
     } else if( configMode == "set" && parser.positionalArguments().size() == 3) {
-        actions.setConfig(parser.positionalArguments()[1], parser.positionalArguments()[2]);
+        Settings::instance.setConfig(parser.positionalArguments()[1], parser.positionalArguments()[2]);
         return EXIT_SUCCESS;
     } else {
       qOut << "Get all variables  : --config get\n"

--- a/QBeat/settings.cpp
+++ b/QBeat/settings.cpp
@@ -25,6 +25,17 @@ Settings::~Settings()
 {
 }
 
+void Settings::setConfig(QString key, QString val) {
+    if( key == kBSInstall ||
+        key == kWinePrefix ||
+        key == kBSProtonDir ) {
+        sanitisePath(val);
+    }
+  if( contains(key) ) {
+    setValue(key, val);
+  }
+}
+
 void Settings::gameVersion(QString version) {
   setValue(kGameVersion, version);
 }

--- a/QBeat/settings.h
+++ b/QBeat/settings.h
@@ -42,6 +42,8 @@ signals:
   void bsInstallChanged();
 
 public:
+  void setConfig(QString key, QString value);
+
   /**
    * Game version
    */


### PR DESCRIPTION
gui disabled unless user asks for it
'~' should now be handled correctly (attempt 2)
--remove implemented for mod removal
Script output logged if patching/etc fails