### PR TITLE
Tidy up bash scripts

### DIFF
--- a/scripts/bs-linux-is-wine-valid.sh
+++ b/scripts/bs-linux-is-wine-valid.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+#set -euo pipefail
 
 # Copyright (c) 2019, Gareth Francis (gfrancis.dev@gmail.com)
 # All rights reserved.
@@ -37,25 +37,25 @@ set -euo pipefail
 # Returns: 0 if the prefix seems valid
 
 if [ $# -ne 1 ]; then
-	echo "USAGE: ${0} <Wine Prefix>: Validates whether a wine prefix is setup for running BSIPA"
-	exit 1
+  echo "USAGE: ${0} <Wine Prefix>: Validates whether a wine prefix is setup for running BSIPA"
+  exit 1
 fi
 
 if ! command -v wine > /dev/null; then
-	echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
-	exit 1
+  echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
+  exit 1
 fi
 
 winePrefix=$(realpath ${1})
 
 if [ ! -d "${winePrefix}" ]; then
-	echo "ERROR: Wine prefix at ${winePrefix} doesn't exist"
-	exit 1
+  echo "ERROR: Wine prefix at ${winePrefix} doesn't exist"
+  exit 1
 fi
 
 if [ ! -f "${winePrefix}/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/Microsoft.CSharp.dll" ]; then
-	echo "ERROR: Wine prefix at ${winePrefix} doesn't contain the expected .Net installation"
-	exit 1
+  echo "ERROR: Wine prefix at ${winePrefix} doesn't contain the expected .Net installation"
+  exit 1
 fi
 
 echo "SUCCESS: Wine prefix at ${winePrefix} should be able to run BSIPA"

--- a/scripts/bs-linux-is-wine-valid.sh
+++ b/scripts/bs-linux-is-wine-valid.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Copyright (c) 2019, Gareth Francis (gfrancis.dev@gmail.com)
 # All rights reserved.
@@ -36,12 +37,11 @@
 # Returns: 0 if the prefix seems valid
 
 if [ $# -ne 1 ]; then
-  echo "USAGE: ${0} <Wine Prefix>: Validates whether a wine prefix is setup for running BSIPA"
-  exit 1
+	echo "USAGE: ${0} <Wine Prefix>: Validates whether a wine prefix is setup for running BSIPA"
+	exit 1
 fi
 
-which wine > /dev/null
-if [ $? -ne 0 ]; then
+if ! command -v wine > /dev/null; then
 	echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
 	exit 1
 fi
@@ -49,14 +49,13 @@ fi
 winePrefix=$(realpath ${1})
 
 if [ ! -d "${winePrefix}" ]; then
-  echo "ERROR: Wine prefix at ${winePrefix} doesn't exist"
-  exit 1
+	echo "ERROR: Wine prefix at ${winePrefix} doesn't exist"
+	exit 1
 fi
 
 if [ ! -f "${winePrefix}/drive_c/windows/Microsoft.NET/Framework/v4.0.30319/Microsoft.CSharp.dll" ]; then
-  echo "ERROR: Wine prefix at ${winePrefix} doesn't contain the expected .Net installation"
-  exit 1
+	echo "ERROR: Wine prefix at ${winePrefix} doesn't contain the expected .Net installation"
+	exit 1
 fi
 
 echo "SUCCESS: Wine prefix at ${winePrefix} should be able to run BSIPA"
-exit 0

--- a/scripts/bs-linux-modfix.sh
+++ b/scripts/bs-linux-modfix.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#set -euo pipefail
 
 # Copyright (c) 2019, Gareth Francis (gfrancis.dev@gmail.com)
 # All rights reserved.
@@ -31,44 +32,46 @@ compatTools="${HOME}/.steam/root/compatibilitytools.d/"
 bsProtonDir="${compatTools}/${bsProtonName}"
 compatData="${bsInstall}/../../compatdata/620980"
 
-echo "This script will setup beat saber mods on your system"
-echo "Before running make sure the following have been done:"
-echo " - Wine is installed on your system"
-echo " - Your wine installation supports .Net 4.6.1 or higher"
-echo " - Beat Saber has been installed through steam"
-echo " - Beat Saber has been run/played at least once"
-echo " - BeatDrop or ModAssistant has been run, and the BSIPA mod has been installed (Don't worry if IPA.exe didn't patch correctly, we'll handle that here"
-echo " - Ideally that the copy of proton passed to this script has not been modified, or if so has been reinstalled through steam first (Feel free to try with a dirty copy, might be bugs in that case)"
-echo ""
-echo "To run this script you need to pass 2 arguments:"
-echo " - The installation folder of beat saber itself e.g SteamApps/common/Beat Saber"
-echo " - The installation folder of the Proton version you want to use e.g SteamApps/common/Proton 4.11"
-echo ""
-echo "The Proton installation will be copied to ~/.steam/root/compatibilitytools.d/Proton BeatSaber"
-echo "TODO: To workaround https://github.com/beat-saber-modding-group/BeatSaber-IPA-Reloaded/issues/18 this script will modify SteamApps/compatdata/620980. If something doesn't work right just delete this folder and validate your beat saber installation"
-echo ""
-echo "After running this script you will need to"
-echo " - Restart Steam"
-echo " - Change the proton version user for beat saber to 'Proton BeatSaber'"
-echo " - Go have fun <3"
+cat << EOF
+This script will setup beat saber mods on your system
+Before running make sure the following have been done:
+ - Wine is installed on your system
+ - Your wine installation supports .Net 4.6.1 or higher
+ - Beat Saber has been installed through steam
+ - Beat Saber has been run/played at least once
+ - BeatDrop or ModAssistant has been run, and the BSIPA mod has been installed (Don't worry if IPA.exe didn't patch correctly, we'll handle that here
+ - Ideally that the copy of proton passed to this script has not been modified, or if so has been reinstalled through steam first (Feel free to try with a dirty copy, might be bugs in that case)
+
+To run this script you need to pass 2 arguments:
+ - The installation folder of beat saber itself e.g SteamApps/common/Beat Saber
+ - The installation folder of the Proton version you want to use e.g SteamApps/common/Proton 4.11
+
+The Proton installation will be copied to ~/.steam/root/compatibilitytools.d/Proton BeatSaber
+TODO: To workaround https://github.com/beat-saber-modding-group/BeatSaber-IPA-Reloaded/issues/18 this script will modify SteamApps/compatdata/620980. If something doesn't work right just delete this folder and validate your beat saber installation
+
+After running this script you will need to
+ - Restart Steam
+ - Change the proton version user for beat saber to 'Proton BeatSaber'
+ - Go have fun <3
+EOF
 
 if [ $# -lt 2 ]; then
-  echo "USAGE: ./bs-linux-modfix.sh <Beat Saber Install directory> <Beat Saber Proton Installation> [Wine Prefix (Optional)]"
+	echo "USAGE: ./bs-linux-modfix.sh <Beat Saber Install directory> <Beat Saber Proton Installation> [Wine Prefix (Optional)]"
 	exit 1
 fi
 
 if [ $# -ne 3 ]; then
-  winePrefix=${WINEPREFIX}
-  if [ ! -d ${winePrefix} ]; then
-    winePrefix="$HOME/.wine"
-  fi
+	winePrefix=${WINEPREFIX}
+	if [ ! -d ${winePrefix} ]; then
+		winePrefix="$HOME/.wine"
+	fi
 else
-  winePrefix=${3}
+	winePrefix=${3}
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} > /dev/null; then
-  echo "ERROR: Your wine installation doesn't appear to be valid, please ensure you have wine installed, and .Net 4.6.1 is installed in \$WINEPREFIX"
-  exit 1
+	echo "ERROR: Your wine installation doesn't appear to be valid, please ensure you have wine installed, and .Net 4.6.1 is installed in \$WINEPREFIX"
+	exit 1
 fi
 
 bsInstall=$(realpath "${1}")
@@ -77,9 +80,8 @@ protonInstall=$(realpath "${2}")
 echo "Creating custom Proton installation for Beat Saber use"
 rm -rf "${bsProtonDir}" || true
 mkdir -p "${compatTools}"
-cp -r "${protonInstall}" "${bsProtonDir}"
 
-if [ $? -ne 0 ]; then
+if ! cp -r "${protonInstall}" "${bsProtonDir}"; then
 	echo "Failed to copy Proton installation"
 	exit 1
 fi
@@ -111,9 +113,7 @@ pushd "${bsInstall}" &> /dev/null
 #WINEPATH="${bsProtonDir}/dist/bin/wine64" WINEPREFIX="${bsProtonDir}/dist/share/default_pfx" "${bsProtonDir}/dist/bin/wine64" IPA.exe
 # TODO: Would be nice to be able to detect if .net 4.6.1 is supported by wine and quit otherwise
 # For now system wine must be setup with at least dotnet461 installed
-WINEPREFIX=${winePrefix} wine IPA.exe -n 2> /dev/null
-
-if [ $? -ne 0 ]; then
+if ! WINEPREFIX=${winePrefix} wine IPA.exe -n 2> /dev/null; then
 	echo "WARNING: IPA.exe returned non-zero result"
 fi
 
@@ -123,12 +123,11 @@ echo '[Software\\Wine\\DllOverrides]' >> "${userRegFile}"
 echo '"winhttp"="native,builtin"' >> "${userRegFile}"
 
 if [ $? -ne 0 ]; then
-        echo "ERROR: Failed to add Wine DllOverrides to ${userRegFile}"
+	echo "ERROR: Failed to add Wine DllOverrides to ${userRegFile}"
 	exit 1
 fi
 
 echo ""
-echo "SUCCESS: Beat Saber has been modded successfully, have fun hitting block <3"
+echo "SUCCESS: Beat Saber has been modded successfully, have fun hitting blocks <3"
 
 popd &> /dev/null
-

--- a/scripts/bs-linux-modfix.sh
+++ b/scripts/bs-linux-modfix.sh
@@ -56,22 +56,22 @@ After running this script you will need to
 EOF
 
 if [ $# -lt 2 ]; then
-	echo "USAGE: ./bs-linux-modfix.sh <Beat Saber Install directory> <Beat Saber Proton Installation> [Wine Prefix (Optional)]"
-	exit 1
+  echo "USAGE: ./bs-linux-modfix.sh <Beat Saber Install directory> <Beat Saber Proton Installation> [Wine Prefix (Optional)]"
+  exit 1
 fi
 
 if [ $# -ne 3 ]; then
-	winePrefix=${WINEPREFIX}
-	if [ ! -d ${winePrefix} ]; then
-		winePrefix="$HOME/.wine"
-	fi
+  winePrefix=${WINEPREFIX}
+  if [ ! -d ${winePrefix} ]; then
+    winePrefix="$HOME/.wine"
+  fi
 else
-	winePrefix=${3}
+  winePrefix=${3}
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} > /dev/null; then
-	echo "ERROR: Your wine installation doesn't appear to be valid, please ensure you have wine installed, and .Net 4.6.1 is installed in \$WINEPREFIX"
-	exit 1
+  echo "ERROR: Your wine installation doesn't appear to be valid, please ensure you have wine installed, and .Net 4.6.1 is installed in \$WINEPREFIX"
+  exit 1
 fi
 
 bsInstall=$(realpath "${1}")
@@ -82,8 +82,8 @@ rm -rf "${bsProtonDir}" || true
 mkdir -p "${compatTools}"
 
 if ! cp -r "${protonInstall}" "${bsProtonDir}"; then
-	echo "Failed to copy Proton installation"
-	exit 1
+  echo "Failed to copy Proton installation"
+  exit 1
 fi
 
 # Setup the tool config for steam
@@ -114,7 +114,7 @@ pushd "${bsInstall}" &> /dev/null
 # TODO: Would be nice to be able to detect if .net 4.6.1 is supported by wine and quit otherwise
 # For now system wine must be setup with at least dotnet461 installed
 if ! WINEPREFIX=${winePrefix} wine IPA.exe -n 2> /dev/null; then
-	echo "WARNING: IPA.exe returned non-zero result"
+  echo "WARNING: IPA.exe returned non-zero result"
 fi
 
 # Configure wine registry to ensure winhttp.dll loads correctly
@@ -123,8 +123,8 @@ echo '[Software\\Wine\\DllOverrides]' >> "${userRegFile}"
 echo '"winhttp"="native,builtin"' >> "${userRegFile}"
 
 if [ $? -ne 0 ]; then
-	echo "ERROR: Failed to add Wine DllOverrides to ${userRegFile}"
-	exit 1
+  echo "ERROR: Failed to add Wine DllOverrides to ${userRegFile}"
+  exit 1
 fi
 
 echo ""

--- a/scripts/bs-linux-setup-wine.sh
+++ b/scripts/bs-linux-setup-wine.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Copyright (c) 2019, Gareth Francis (gfrancis.dev@gmail.com)
 # All rights reserved.
@@ -35,29 +36,27 @@
 # Returns: 0 if installation was successful
 
 if [ $# -ne 1 ]; then
-  echo "USAGE: ${0} <Wine Prefix> : Sets up a wine prefix for running BSIPA"
-  exit 1
+	echo "USAGE: ${0} <Wine Prefix> : Sets up a wine prefix for running BSIPA"
+	exit 1
 fi
 
 winePrefix=$(realpath ${1})
 
-which wine > /dev/null
-if [ $? -ne 0 ]; then
+if ! command -v wine > /dev/null; then
 	echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
 	exit 1
 fi
 
-which cabextract > /dev/null
-if [ $? -ne 0 ]; then
+if ! command -v cabextract > /dev/null; then
 	echo "ERROR: cabextract is required to install dotnet 4.6.1, please ensure it's in your PATH"
 	exit 1
 fi
 
 mkdir -p ${winePrefix} 2> /dev/null
 pushd ${winePrefix} > /dev/null
-if ! wget  https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks 2> /dev/null; then
-  echo "ERROR: Failed to download winetricks, please log this as a bug at https://github.com/geefr/beatsaber-linux-goodies"
-  exit 1
+if ! wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks 2> /dev/null; then
+	echo "ERROR: Failed to download winetricks, please log this as a bug at https://github.com/geefr/beatsaber-linux-goodies"
+	exit 1
 fi
 chmod +x winetricks
 popd > /dev/null
@@ -68,9 +67,8 @@ if ! WINEPREFIX=${winePrefix} ${winePrefix}/winetricks dotnet461 2> /dev/null; t
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} &> /dev/null; then
-  echo "ERROR: .Net installation succeeded but wine prefix doesn't appear valid"
-  exit 1
+	echo "ERROR: .Net installation succeeded but wine prefix doesn't appear valid"
+	exit 1
 fi
 
 echo "SUCCESS: Wine prefix at ${winePrefix} setup to run BSIPA"
-exit 0

--- a/scripts/bs-linux-setup-wine.sh
+++ b/scripts/bs-linux-setup-wine.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+#set -euo pipefail
 
 # Copyright (c) 2019, Gareth Francis (gfrancis.dev@gmail.com)
 # All rights reserved.
@@ -36,39 +36,39 @@ set -euo pipefail
 # Returns: 0 if installation was successful
 
 if [ $# -ne 1 ]; then
-	echo "USAGE: ${0} <Wine Prefix> : Sets up a wine prefix for running BSIPA"
-	exit 1
+  echo "USAGE: ${0} <Wine Prefix> : Sets up a wine prefix for running BSIPA"
+  exit 1
 fi
 
 winePrefix=$(realpath ${1})
 
 if ! command -v wine > /dev/null; then
-	echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
-	exit 1
+  echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
+  exit 1
 fi
 
 if ! command -v cabextract > /dev/null; then
-	echo "ERROR: cabextract is required to install dotnet 4.6.1, please ensure it's in your PATH"
-	exit 1
+  echo "ERROR: cabextract is required to install dotnet 4.6.1, please ensure it's in your PATH"
+  exit 1
 fi
 
 mkdir -p ${winePrefix} 2> /dev/null
 pushd ${winePrefix} > /dev/null
 if ! wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks 2> /dev/null; then
-	echo "ERROR: Failed to download winetricks, please log this as a bug at https://github.com/geefr/beatsaber-linux-goodies"
-	exit 1
+  echo "ERROR: Failed to download winetricks, please log this as a bug at https://github.com/geefr/beatsaber-linux-goodies"
+  exit 1
 fi
 chmod +x winetricks
 popd > /dev/null
 
 if ! WINEPREFIX=${winePrefix} ${winePrefix}/winetricks dotnet461 2> /dev/null; then
-	echo "ERROR: Failed to install .Net 4.6.1"
-	exit 1
+  echo "ERROR: Failed to install .Net 4.6.1"
+  exit 1
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} &> /dev/null; then
-	echo "ERROR: .Net installation succeeded but wine prefix doesn't appear valid"
-	exit 1
+  echo "ERROR: .Net installation succeeded but wine prefix doesn't appear valid"
+  exit 1
 fi
 
 echo "SUCCESS: Wine prefix at ${winePrefix} setup to run BSIPA"


### PR DESCRIPTION
Add `set -euo pipefail` (except for modfix)
Switch from which to command -v, which is more portable
Use tabs everywhere instead of a mix of randomly long tabs and spaces
Tidied up other things

I do not understand why the scripts say `# Arguments: None`

But then go on and use arguments `winePrefix=$(realpath ${1})`