### PR TITLE
Modify wine setup script behaviour

### DIFF
--- a/scripts/bs-linux-setup-wine.sh
+++ b/scripts/bs-linux-setup-wine.sh
@@ -44,6 +44,7 @@ if [ $# -ne 1 ]; then
 fi
 
 winePrefix=$(realpath ${1})
+prefixExists=0
 
 if ! command -v wine > /dev/null; then
   echo "ERROR: Wine doesn't appear to be installed on your system, please do so and ensure it's in your PATH"
@@ -54,6 +55,18 @@ if ! command -v cabextract > /dev/null; then
   echo "ERROR: cabextract is required to install dotnet 4.6.1, please ensure it's in your PATH"
   exit 1
 fi
+
+function prefixwarn {
+  if [ $prefixExists -eq 1 ]; then
+    echo "WARN: A Wine prefix already exists at ${winePrefix}. If you experience any issues, please delete the prefix, or use a different prefix."
+  fi
+}
+
+if [ -d "${winePrefix}" ]; then
+  prefixExists=1
+fi
+
+prefixwarn
 
 mkdir -p ${winePrefix} 2> /dev/null
 pushd ${winePrefix} > /dev/null
@@ -69,12 +82,15 @@ popd > /dev/null
 
 if ! WINEPREFIX=${winePrefix} ${winePrefix}/winetricks dotnet461 2> /dev/null; then
   echo "ERROR: Failed to install .Net 4.6.1"
+  prefixwarn
   exit 1
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} &> /dev/null; then
   echo "ERROR: .Net installation succeeded but wine prefix doesn't appear valid"
+  prefixwarn
   exit 1
 fi
 
+prefixwarn
 echo "SUCCESS: Wine prefix at ${winePrefix} setup to run BSIPA"

--- a/scripts/bs-linux-setup-wine.sh
+++ b/scripts/bs-linux-setup-wine.sh
@@ -60,7 +60,7 @@ pushd ${winePrefix} > /dev/null
 if [ -z $WINETRICKSURL ]; then
   WINETRICKSURL=https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks
 fi
-if ! wget $WINETRICKSURL 2> /dev/null; then
+if ! wget $WINETRICKSURL -O winetricks 2> /dev/null; then
   echo "ERROR: Failed to download winetricks, please log this as a bug at https://github.com/geefr/beatsaber-linux-goodies"
   exit 1
 fi


### PR DESCRIPTION
This PR modifies the wine setup script's behaviour in an attempt to reduce the number of non-bugs getting into issues. 
The current commit amends wget's behaviour in the wine setup script to overwrite a pre-existing winetricks script. This means that if a user has ran this script and downloaded a bad version of winetricks which does not work, they do not have to delete it. The issues caused by not doing so have already been shown in issue #50, where wget did not overwrite the broken winetricks script, causing significant confusion.
 
Ideally, we would be deleting a pre-existing Wine prefix instead, however that would impact users running only one prefix for multiple applications. 
What are your thoughts of these ideas for further modifications before this PR is marked ready for review:
There should be a check for a pre-existing Wine prefix which warns the user both before and after the script runs with a message something like "WARN: A pre-existing Wine prefix was detected. Please delete it and/or use an independent prefix before reporting an issue."
Also, the script should delete the Wine prefix it made if installation or verification fails, or it should at the very least instruct the user to delete it and start again if it doesn't work.

Any comments would be appreciated, and I will commit further to this branch before marking ready for review if my further ideas are deemed sensible.