### PR TITLE
Wine bug 49532 workaround

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ These scripts checks to see if your wine prefix is setup for running BSIPA, and 
 ./bs-linux-is-wine-valid.sh ~/.wine
 
 # If this script returns non-zero, or shows an error your wine won't be able to patch beat saber
-# For this just run the other script, and follow the prompts when the various setup wizards appear
+# For this just run the other script
 ./bs-linux-setup-wine.sh
 
 # This script will double-check if the prefix is valid at the end, if it doesn't work please raise a github issue

--- a/scripts/bs-linux-setup-wine.sh
+++ b/scripts/bs-linux-setup-wine.sh
@@ -80,10 +80,28 @@ fi
 chmod +x winetricks
 popd > /dev/null
 
-if ! WINEPREFIX=${winePrefix} ${winePrefix}/winetricks dotnet461 2> /dev/null; then
+wineVersion=`wine --version | cut -d ' ' -f1 | sed -e 's/wine-//' -e 's/-rc.*//'` # Get Wine version
+workaround49532=0
+if [[ $wineVersion > 5.12 ]]; then
+  echo "WARN: Wine version is wine-${wineVersion}; working around wine bug 49532."
+  workaround49532=1
+  ./workarounds/wine-49532-workaround.sh & # Execute workaround script as background process
+  workaround49532pid=$!
+fi
+
+if ! WINEPREFIX=${winePrefix} ${winePrefix}/winetricks -f -q dotnet461 2> /dev/null; then
   echo "ERROR: Failed to install .Net 4.6.1"
+  if [ $workaround49532 -eq 1 ]; then
+    kill "$workaround49532pid"
+    pkill mscorsvw.exe # In case we missed any
+  fi
   prefixwarn
   exit 1
+fi
+
+if [ $workaround49532 -eq 1 ]; then
+  kill "$workaround49532pid"
+  pkill mscorsvw.exe # In case we missed any
 fi
 
 if ! ./bs-linux-is-wine-valid.sh ${winePrefix} &> /dev/null; then

--- a/scripts/workarounds/proc-stopper.sh
+++ b/scripts/workarounds/proc-stopper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+pid=$1
+timedelay=$2
+
+sleep $timedelay
+if [ -d "/proc/${pid}" ]
+then
+  kill $pid
+  echo "Killed $pid"
+fi

--- a/scripts/workarounds/wine-49532-workaround.sh
+++ b/scripts/workarounds/wine-49532-workaround.sh
@@ -26,7 +26,7 @@ do
     if [ "$?" = "0" ]
     then
       newpids+=("$pid")
-      ./proc-stopper.sh $pid 60 &
+      ./workarounds/proc-stopper.sh $pid 60 &
     fi
   done
   #echo "PID DEBUG BELOW"

--- a/scripts/workarounds/wine-49532-workaround.sh
+++ b/scripts/workarounds/wine-49532-workaround.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+function testinarray {
+  local -n array=$1
+  local -n testvalue=$2
+
+  for i in "${array[@]}"
+  do
+    if [ "$i" = "$testvalue" ]
+    then
+      return 1
+    fi
+  done
+  return 0
+}
+
+oldpids=()
+
+while true
+do
+  pids=( $(pgrep mscorsvw.exe | tr "\n" " ") )
+  newpids=()
+  for pid in "${pids[@]}"
+  do
+    testinarray oldpids pid # If pid is new
+    if [ "$?" = "0" ]
+    then
+      newpids+=("$pid")
+      ./proc-stopper.sh $pid 60 &
+    fi
+  done
+  #echo "PID DEBUG BELOW"
+  #echo "All: ${pids[@]}"
+  #echo "New: ${newpids[@]}"
+  #echo "Old: ${oldpids[@]}"
+  oldpids=( ${pids[@]} )
+  sleep 1
+done


### PR DESCRIPTION
This PR implements experimental workarounds for Wine bug 49532. These workarounds have worked consistently throughout my testing, but it would be wise for someone else to test it as well first. The workaround should also not affect any versions of wine below 5.12. 
Fixes #54 