### PR TITLE
Change version api url to correct and reliable one.

### DIFF
--- a/Beataroni/Beataroni/Services/BeatModsV1.cs
+++ b/Beataroni/Beataroni/Services/BeatModsV1.cs
@@ -19,14 +19,14 @@ namespace Beataroni.Services
     /// Note: You MUST not have '//' in the resulting URLs, beatmods can't handle this
     private static readonly string APIRoot = "https://beatmods.com/api/v1";
     private static readonly string APIDownload = "https://beatmods.com";
-    private static readonly string APIVersion = "version";
+    private static readonly string APIVersion = "https://versions.beatmods.com/versions.json";
     private static readonly string APIMod = "mod";
 
     /// Fetch list of beatsaber/mod versions
     /// List will be returned in order sent from server - Should be newest -> oldest
     public static IList<string> FetchBSVersions()
     {
-      var endpoint = $"{APIRoot}/{APIVersion}";
+      var endpoint = $"{APIVersion}";
       
       try
       {

--- a/Beataroni/Beataroni/Services/BeatModsV1.cs
+++ b/Beataroni/Beataroni/Services/BeatModsV1.cs
@@ -17,10 +17,9 @@ namespace Beataroni.Services
 
     /// API endpoints/urls
     /// Note: You MUST not have '//' in the resulting URLs, beatmods can't handle this
-    private static readonly string APIRoot = "https://beatmods.com/api/v1";
     private static readonly string APIDownload = "https://beatmods.com";
     private static readonly string APIVersion = "https://versions.beatmods.com/versions.json";
-    private static readonly string APIMod = "mod";
+    private static readonly string APIMod = "https://beatmods.com/api/v1/mod";
 
     /// Fetch list of beatsaber/mod versions
     /// List will be returned in order sent from server - Should be newest -> oldest
@@ -55,7 +54,7 @@ namespace Beataroni.Services
     /// Typical filters would be game version, installation type, mod status
     public static IList<Mod> FetchMods( Dictionary<string, string> filters )
     {
-      var endpoint = $"{APIRoot}/{APIMod}";
+      var endpoint = $"{APIMod}";
 
       if( filters != null && filters.Count > 0 )
       {

--- a/tui-script/QBeat-tui
+++ b/tui-script/QBeat-tui
@@ -504,7 +504,7 @@ function action-installer-set-config {
 
 function action-installer-set-version {
   # Sets version as part of first-time setup, similarly to action-version-set.
-  versionsarray=( $( curl -sL https://beatmods.com/api/v1/version | sed -e 's/\[//' -e 's/\]//' -e 's/,/\n/g' ) )
+  versionsarray=( $( curl -sL https://versions.beatmods.com/versions.json | sed -e 's/\[//' -e 's/\]//' -e 's/,/\n/g' ) )
 
   echo "Default: ${versionsarray[0]//\"/}"
   echo "Select a version:"
@@ -803,7 +803,7 @@ EOF
   ${scriptpath}/QBeat --config get gameVersion
   echo "-----------------------------"
 
-  versionsarray=( $( curl -sL https://beatmods.com/api/v1/version | sed -e 's/\[//' -e 's/\]//' -e 's/,/\n/g' ) )
+  versionsarray=( $( curl -sL https://versions.beatmods.com/versions | sed -e 's/\[//' -e 's/\]//' -e 's/,/\n/g' ) )
   echo "  Select a version:"
   for i in ${!versionsarray[@]}
   do


### PR DESCRIPTION
Through Discord, I was told by Assistant, the creator of ModAssistant, that the url that we are using is in-fact incorrect, and that the one used by ModAssistant was implemented to bypass the broken one. Therefore, I have updated the URL in both QBeat-tui and in Beataroni. 

Please check that I didn't blindly break anything, because it is very late and I just bashed this together in the nano editor in a few seconds :sweat_smile:  

Edit: Have built and tested -- it works as intended.